### PR TITLE
feat: Provide support for SoapySDR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+scrap/
+
 # Prerequisites
 *.d
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-Iinclude -lm -lfftw3
+CFLAGS=-Iinclude -lm -lfftw3 -lSoapySDR
 SRC=$(wildcard src/*.c)
 TARGET=spectrel
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -1,0 +1,24 @@
+#ifndef SPECTREL_CONSTANTS_H
+#define SPECTREL_CONSTANTS_H
+
+/**
+ * Constant to indicate a successfull action.
+ */
+#define SPECTREL_SUCCESS 0
+
+/**
+ * Constant to indicate an unsuccessful action.
+ */
+#define SPECTREL_FAILURE 1
+
+/**
+ * Constant to indicate that no parameters are required.
+ */
+#define SPECTREL_NO_SIGNAL_PARAMS NULL
+
+/**
+ * Constant to indicate max length of receiver inactivity.
+ */
+#define SPECTREL_TIMEOUT 1e6
+
+#endif // SPECTREL_CONSTANTS_H

--- a/include/receiver.h
+++ b/include/receiver.h
@@ -1,0 +1,60 @@
+#ifndef SPECTREL_RECEIVER_H
+#define SPECTREL_RECEIVER_H
+
+#include "stfft.h"
+
+/**
+ * @brief An opaque pointer to a receiver structure.
+ */
+typedef struct spectrel_receiver_t *spectrel_receiver;
+
+/**
+ * @brief Create a new receiver structure.
+ *
+ * @param name The name of the receiver.
+ * @param frequency The center frequency, in Hz.
+ * @param sample_rate The sample rate, in Hz.
+ * @param bandwidth bandwidth, in Hz.
+ * @param gain The gain, in dB.
+ * @return An opaque pointer to the newly initialised receiver structure.
+ */
+spectrel_receiver spectrel_make_receiver(const char *name,
+                                         const double frequency,
+                                         const double sample_rate,
+                                         const double bandwidth,
+                                         const double gain);
+
+/**
+ * @brief Release resources allocated for a receiver structure.
+ *
+ * This frees all the underlying memory and clears the members.
+ *
+ * @param receiver The receiver structure to be cleared.
+ * @return Zero for success, or an error code on failure.
+ */
+int spectrel_free_receiver(spectrel_receiver receiver);
+
+/**
+ * @brief Activate a stream, to prepare for reading.
+ * @param A pointer to the receiver structure.
+ * @return Zero for success, or an error code on failure.
+ */
+int spectrel_activate_stream(spectrel_receiver receiver);
+
+/**
+ * @brief Activate a stream, to prepare for reading.
+ * @param A pointer to the receiver structure.
+ * @return Zero for success, or an error code on failure.
+ */
+int spectrel_deactivate_stream(spectrel_receiver receiver);
+
+/**
+ * @brief Fill the buffer with samples from the receiver.
+ * @param receiver A pointer to the receiver structure.
+ * @param buffer A pointer to the buffer to fill with samples from the
+ * receiver.
+ * @return Zero for success, or an error code on failure.
+ */
+int spectrel_read_stream(spectrel_receiver receiver, spectrel_signal_t *buffer);
+
+#endif // SPECTREL_DEVICE_H

--- a/include/spectrel.h
+++ b/include/spectrel.h
@@ -1,6 +1,8 @@
 #ifndef SPECTREL_H
 #define SPECTREL_H
 
+#include "constants.h"
+#include "receiver.h"
 #include "stfft.h"
 
 #endif // SPECTREL_H

--- a/include/stfft.h
+++ b/include/stfft.h
@@ -1,8 +1,10 @@
 #ifndef SPECTREL_STFFT_H
 #define SPECTREL_STFFT_H
 
+// Include <complex.h> before <fftw.3> so that fftw_complex is the native
+// double-precision complex.
+#include <complex.h>
 #include <fftw3.h>
-#include <stdlib.h>
 
 /**
  * @brief A discrete, complex-valued signal.
@@ -14,7 +16,7 @@ typedef struct
 } spectrel_signal_t;
 
 /**
- * A supported signal type.
+ * @brief A supported signal type.
  */
 typedef enum
 {
@@ -22,17 +24,6 @@ typedef enum
     SPECTREL_CONSTANT_SIGNAL,
     SPECTREL_COSINE_SIGNAL,
 } spectrel_signal_type_t;
-
-/**
- * @brief Indicate that no parameters are required.
- */
-typedef struct
-{
-
-} spectrel_no_params_t;
-
-// Indicate that no parameters are required.
-#define SPECTREL_NO_PARAMS NULL
 
 /**
  * @brief Parameters for cosine signals.
@@ -75,13 +66,16 @@ typedef struct
  * sample.
  * @param signal The signal to describe.
  */
-void describe_signal(const spectrel_signal_t *signal);
+void spectrel_describe_signal(const spectrel_signal_t *signal);
 
 /**
  * @brief Frees memory used by a signal.
+ *
+ *  This frees all the underlying memory and clears the members.
+ *
  * @param signal Pointer to the signal to free.
  */
-void free_signal(spectrel_signal_t *signal);
+void spectrel_free_signal(spectrel_signal_t *signal);
 
 /**
  * @brief Generate a discrete, complex-valued signal.
@@ -90,9 +84,10 @@ void free_signal(spectrel_signal_t *signal);
  * @param params Configurable parameters for the specified signal type.
  * @return The signal.
  */
-spectrel_signal_t *make_signal(const size_t num_samples,
-                               const spectrel_signal_type_t signal_type,
-                               void *params);
+spectrel_signal_t *
+spectrel_make_signal(const size_t num_samples,
+                     const spectrel_signal_type_t signal_type,
+                     void *params);
 
 /**
  * @brief An opaque structure encapsulating the information to carry out an
@@ -101,17 +96,37 @@ spectrel_signal_t *make_signal(const size_t num_samples,
 typedef struct spectrel_plan_t *spectrel_plan;
 
 /**
+ * @brief Free all resources allocated by a plan.
+ *
+ * This frees all the underlying memory and clears the members.
+ *
+ * @param The plan to destroy.
+ * @return Zero for success, or an error code on failure.
+ */
+void spectrel_free_plan(spectrel_plan p);
+
+/**
  * @brief Plan an in-place 1D DFT on a buffer.
  * @param buffer_size The number of samples in the buffer.
  * @return The plan.
  */
-spectrel_plan make_plan(const size_t buffer_size);
+spectrel_plan spectrel_make_plan(const size_t buffer_size);
 
 /**
- * @brief Free all resources allocated by a plan.
- * @param The plan to destroy.
+ * @brief Print properties of the spectrogram, and the values of each
+ * sample.
+ * @param signal The signal to describe.
  */
-void free_plan(spectrel_plan p);
+void spectrel_describe_spectrogram(const spectrel_spectrogram_t *spectrogram);
+
+/**
+ * @brief Frees memory used by a spectrogram.
+ *
+ * This frees all the underlying memory and clears the members.
+ *
+ * @param signal Pointer to the spectrogram to free.
+ */
+void spectrel_free_spectrogram(spectrel_spectrogram_t *spectrogram);
 
 /**
  * @brief Compute the short-time discrete Fourier transform of the input signal
@@ -128,23 +143,10 @@ void free_plan(spectrel_plan p);
  * @param sample_rate The sample rate of the signal.
  * @return A spectrogram containing the amplitude of each spectral component.
  */
-spectrel_spectrogram_t *stfft(spectrel_plan p,
-                              const spectrel_signal_t *window,
-                              const spectrel_signal_t *signal,
-                              const size_t window_hop,
-                              const double sample_rate);
-
-/**
- * @brief Print properties of the spectrogram, and the values of each
- * sample.
- * @param signal The signal to describe.
- */
-void describe_spectrogram(const spectrel_spectrogram_t *spectrogram);
-
-/**
- * @brief Frees memory used by a spectrogram
- * @param signal Pointer to the spectrogram to free.
- */
-void free_spectrogram(spectrel_spectrogram_t *spectrogram);
+spectrel_spectrogram_t *spectrel_stfft(spectrel_plan p,
+                                       const spectrel_signal_t *window,
+                                       const spectrel_signal_t *signal,
+                                       const size_t window_hop,
+                                       const double sample_rate);
 
 #endif

--- a/src/receiver.c
+++ b/src/receiver.c
@@ -1,0 +1,167 @@
+#include "receiver.h"
+#include "constants.h"
+#include "stfft.h"
+
+#include <SoapySDR/Constants.h>
+#include <SoapySDR/Device.h>
+#include <SoapySDR/Formats.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+struct spectrel_receiver_t
+{
+    SoapySDRDevice *device;
+    SoapySDRStream *rx_stream;
+};
+
+int spectrel_free_receiver(spectrel_receiver receiver)
+{
+    if (receiver->device && receiver->rx_stream)
+    {
+        if (SoapySDRDevice_closeStream(receiver->device, receiver->rx_stream) !=
+            0)
+        {
+            fprintf(
+                stderr, "closeStream fail: %s\n", SoapySDRDevice_lastError());
+            return SPECTREL_FAILURE;
+        }
+        receiver->rx_stream = NULL;
+    }
+
+    if (receiver->device)
+    {
+        if (SoapySDRDevice_unmake(receiver->device) != 0)
+        {
+            fprintf(stderr, "unmake fail: %s\n", SoapySDRDevice_lastError());
+            return SPECTREL_FAILURE;
+        }
+        receiver->device = NULL;
+    }
+    free(receiver);
+    return SPECTREL_SUCCESS;
+}
+
+spectrel_receiver spectrel_make_receiver(const char *name,
+                                         const double frequency,
+                                         const double sample_rate,
+                                         const double bandwidth,
+                                         const double gain)
+{
+
+    // Prepare receiver structure with safe initial values.
+    spectrel_receiver receiver = malloc(sizeof(*receiver));
+
+    if (!receiver)
+    {
+        fprintf(
+            stderr,
+            "Malloc fail: Failed to allocate memory for the receiver pointer.");
+        return NULL;
+    }
+
+    receiver->device = NULL;
+    receiver->rx_stream = NULL;
+
+    // Make the soapy device for the receiver, interpreting the receiver name as
+    // the device driver.
+    SoapySDRKwargs args = {};
+    SoapySDRKwargs_set(&args, "driver", name);
+    receiver->device = SoapySDRDevice_make(&args);
+    SoapySDRKwargs_clear(&args);
+
+    if (!receiver->device)
+    {
+        fprintf(stderr, "make fail: %s\n", SoapySDRDevice_lastError());
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
+
+    // Set the configurable parameters for the soapy device.
+    if (SoapySDRDevice_setFrequency(
+            receiver->device, SOAPY_SDR_RX, 0, frequency, NULL) != 0)
+    {
+        fprintf(stderr, "setFrequency fail: %s\n", SoapySDRDevice_lastError());
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
+
+    if (SoapySDRDevice_setSampleRate(
+            receiver->device, SOAPY_SDR_RX, 0, sample_rate) != 0)
+    {
+        fprintf(stderr, "setSampleRate fail: %s\n", SoapySDRDevice_lastError());
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
+
+    if (SoapySDRDevice_setBandwidth(
+            receiver->device, SOAPY_SDR_RX, 0, bandwidth) != 0)
+    {
+        fprintf(stderr, "setBandwidth fail: %s\n", SoapySDRDevice_lastError());
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
+
+    if (SoapySDRDevice_setGain(receiver->device, SOAPY_SDR_RX, 0, gain) != 0)
+    {
+        fprintf(stderr, "setGain fail: %s\n", SoapySDRDevice_lastError());
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
+
+    // Set up the stream.
+    receiver->rx_stream = SoapySDRDevice_setupStream(
+        receiver->device, SOAPY_SDR_RX, SOAPY_SDR_CF64, NULL, 0, NULL);
+    if (!receiver->rx_stream)
+    {
+        fprintf(stderr, "setupStream fail: %s\n", SoapySDRDevice_lastError());
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
+
+    return receiver;
+}
+
+int spectrel_activate_stream(spectrel_receiver receiver)
+{
+    if (SoapySDRDevice_activateStream(
+            receiver->device, receiver->rx_stream, 0, 0, 0) != 0)
+    {
+        fprintf(
+            stderr, "activateStream fail: %s\n", SoapySDRDevice_lastError());
+        return SPECTREL_FAILURE;
+    }
+    return SPECTREL_SUCCESS;
+}
+
+int spectrel_deactivate_stream(spectrel_receiver receiver)
+{
+    if (SoapySDRDevice_deactivateStream(
+            receiver->device, receiver->rx_stream, 0, 0) != 0)
+    {
+        fprintf(
+            stderr, "deactivateStream fail: %s\n", SoapySDRDevice_lastError());
+        return SPECTREL_FAILURE;
+    }
+    return SPECTREL_SUCCESS;
+}
+
+int spectrel_read_stream(spectrel_receiver receiver, spectrel_signal_t *buffer)
+{
+    void *buffers[] = {buffer->samples};
+    int ret = SoapySDRDevice_readStream(receiver->device,
+                                        receiver->rx_stream,
+                                        buffers,
+                                        buffer->num_samples,
+                                        0,
+                                        0,
+                                        SPECTREL_TIMEOUT);
+
+    return (ret > 0) ? SPECTREL_SUCCESS : SPECTREL_FAILURE;
+}


### PR DESCRIPTION
- Provide support for SoapySDR and hide it behind our own interface.
- Basic support to stream samples from the receiver and transform them into spectrograms. These are not yet written to file or displayed.
- Uniform namespacing by prefix.
- Doxygen style comments in the header files.