### PR TITLE
feat: Validate configurable parameters against hardware constraints

### DIFF
--- a/include/spreceiver.h
+++ b/include/spreceiver.h
@@ -4,25 +4,20 @@
 #include "spsignal.h"
 
 /**
+ * @brief A bundle of configurable receiver parameters.
+ */
+typedef struct
+{
+    double frequency;   // The center frequency, in Hz.
+    double sample_rate; // The sample rate, in Hz.
+    double bandwidth;   // The bandwidth, in Hz.
+    double gain;        // The gain, in dB.
+} spectrel_receiver_params_t;
+
+/**
  * @brief An opaque pointer to a receiver structure.
  */
 typedef struct spectrel_receiver_t *spectrel_receiver;
-
-/**
- * @brief Create a new receiver structure.
- *
- * @param driver A SDR driver supported by Soapy.
- * @param frequency The center frequency, in Hz.
- * @param sample_rate The sample rate, in Hz.
- * @param bandwidth bandwidth, in Hz.
- * @param gain The gain, in dB.
- * @return An opaque pointer to the newly initialised receiver structure.
- */
-spectrel_receiver spectrel_make_receiver(const char *driver,
-                                         const double frequency,
-                                         const double sample_rate,
-                                         const double bandwidth,
-                                         const double gain);
 
 /**
  * @brief Release resources allocated for a receiver structure.
@@ -35,15 +30,33 @@ spectrel_receiver spectrel_make_receiver(const char *driver,
 int spectrel_free_receiver(spectrel_receiver receiver);
 
 /**
+ * @brief Create a new receiver structure.
+ * @param driver An SDR driver supported by Soapy.
+ * @param params A bundle of configurable receiver parameters.
+ * @return An opaque pointer to the newly initialised receiver structure.
+ */
+spectrel_receiver spectrel_make_receiver(const char *driver,
+                                         spectrel_receiver_params_t *params);
+
+/**
+ * @brief Get the current configured parameters for a receiver.
+ * @param receiver The receiver structure to be queried.
+ * @param params Pointer to struct where current parameters will be written.
+ * @return Zero for success, or an error code on failure.
+ */
+int spectrel_get_parameters(spectrel_receiver receiver,
+                            spectrel_receiver_params_t *params);
+
+/**
  * @brief Activate a stream, to prepare for reading.
- * @param A pointer to the receiver structure.
+ * @param receiver A pointer to the receiver structure.
  * @return Zero for success, or an error code on failure.
  */
 int spectrel_activate_stream(spectrel_receiver receiver);
 
 /**
  * @brief Deactivate the stream for a receiver structure.
- * @param A pointer to the receiver structure.
+ * @param receiver A pointer to the receiver structure.
  * @return Zero for success, or an error code on failure.
  */
 int spectrel_deactivate_stream(spectrel_receiver receiver);
@@ -56,5 +69,12 @@ int spectrel_deactivate_stream(spectrel_receiver receiver);
  * @return Zero for success, or an error code on failure.
  */
 int spectrel_read_stream(spectrel_receiver receiver, spectrel_signal_t *buffer);
+
+/**
+ * @brief Print properties of the receiver, and the values of it's configured
+ * parameters.
+ * @param receiver The receiver struct to be described.
+ */
+void spectrel_describe_receiver(spectrel_receiver receiver);
 
 #endif // SPRECEIVER_H

--- a/src/spreceiver.c
+++ b/src/spreceiver.c
@@ -8,6 +8,7 @@
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Formats.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -19,6 +20,11 @@ struct spectrel_receiver_t
 
 int spectrel_free_receiver(spectrel_receiver receiver)
 {
+    if (!receiver)
+    {
+        return SPECTREL_SUCCESS;
+    }
+
     if (receiver->device && receiver->rx_stream)
     {
         if (SoapySDRDevice_closeStream(receiver->device, receiver->rx_stream) !=
@@ -45,31 +51,58 @@ int spectrel_free_receiver(spectrel_receiver receiver)
     return SPECTREL_SUCCESS;
 }
 
+static bool is_value_in_ranges(double value,
+                               const SoapySDRRange *ranges,
+                               size_t range_count)
+{
+    for (size_t i = 0; i < range_count; i++)
+    {
+        SoapySDRRange range = ranges[i];
+        if (range.minimum == range.maximum)
+        {
+            if (value == range.minimum)
+            {
+                return true;
+            }
+        }
+        if (value >= range.minimum && value <= range.maximum)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool is_value_in_range(double value, const SoapySDRRange *range)
+{
+    return value >= range->minimum && value <= range->maximum;
+}
+
 spectrel_receiver spectrel_make_receiver(const char *driver,
-                                         const double frequency,
-                                         const double sample_rate,
-                                         const double bandwidth,
-                                         const double gain)
+                                         spectrel_receiver_params_t *params)
 {
 
     // Prepare receiver structure with safe initial values.
     spectrel_receiver receiver = malloc(sizeof(*receiver));
-
     if (!receiver)
     {
-        spectrel_print_error("Memory allocation failed for receiver");
+        spectrel_print_error("malloc failed: receiver");
         return NULL;
     }
-
     receiver->device = NULL;
     receiver->rx_stream = NULL;
 
     // Make the soapy device for the receiver.
     SoapySDRKwargs args = {};
-    SoapySDRKwargs_set(&args, "driver", driver);
+    if (SoapySDRKwargs_set(&args, "driver", driver) != 0)
+    {
+        spectrel_print_error("set fail");
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        return NULL;
+    }
     receiver->device = SoapySDRDevice_make(&args);
     SoapySDRKwargs_clear(&args);
-
     if (!receiver->device)
     {
         spectrel_free_receiver(receiver);
@@ -79,9 +112,30 @@ spectrel_receiver spectrel_make_receiver(const char *driver,
         return NULL;
     }
 
-    // Set the configurable parameters for the soapy device.
+    size_t range_size = 0;
+
+    // Set the frequency, first checking it's in range.
+    SoapySDRRange *frequency_ranges = SoapySDRDevice_getFrequencyRange(
+        receiver->device, SOAPY_SDR_RX, 0, &range_size);
+    if (!frequency_ranges || range_size == 0)
+    {
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("getFrequencyRange failed: %s",
+                             SoapySDRDevice_lastError());
+        return NULL;
+    }
+    if (!is_value_in_ranges(params->frequency, frequency_ranges, range_size))
+    {
+        SoapySDR_free(frequency_ranges);
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("Invalid frequency: %lf [Hz]", params->frequency);
+        return NULL;
+    }
+    SoapySDR_free(frequency_ranges);
     if (SoapySDRDevice_setFrequency(
-            receiver->device, SOAPY_SDR_RX, 0, frequency, NULL) != 0)
+            receiver->device, SOAPY_SDR_RX, 0, params->frequency, NULL) != 0)
     {
         spectrel_free_receiver(receiver);
         receiver = NULL;
@@ -90,8 +144,32 @@ spectrel_receiver spectrel_make_receiver(const char *driver,
         return NULL;
     }
 
+    // Set the sample rate.
+    range_size = 0;
+    SoapySDRRange *sample_rate_ranges = SoapySDRDevice_getSampleRateRange(
+        receiver->device, SOAPY_SDR_RX, 0, &range_size);
+    if (!sample_rate_ranges || range_size == 0)
+    {
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("getSampleRateRange failed: %s",
+                             SoapySDRDevice_lastError());
+        return NULL;
+    }
+    if (!is_value_in_ranges(
+            params->sample_rate, sample_rate_ranges, range_size))
+    {
+        SoapySDR_free(sample_rate_ranges);
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("Invalid sample rate: %lf [Hz]",
+                             params->sample_rate);
+        return NULL;
+    }
+    SoapySDR_free(sample_rate_ranges);
+
     if (SoapySDRDevice_setSampleRate(
-            receiver->device, SOAPY_SDR_RX, 0, sample_rate) != 0)
+            receiver->device, SOAPY_SDR_RX, 0, params->sample_rate) != 0)
     {
         spectrel_free_receiver(receiver);
         receiver = NULL;
@@ -100,8 +178,29 @@ spectrel_receiver spectrel_make_receiver(const char *driver,
         return NULL;
     }
 
+    // Set the bandwidth.
+    range_size = 0;
+    SoapySDRRange *bandwidth_ranges = SoapySDRDevice_getBandwidthRange(
+        receiver->device, SOAPY_SDR_RX, 0, &range_size);
+    if (!bandwidth_ranges || range_size == 0)
+    {
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("getBandwidthRange failed: %s",
+                             SoapySDRDevice_lastError());
+        return NULL;
+    }
+    if (!is_value_in_ranges(params->bandwidth, bandwidth_ranges, range_size))
+    {
+        SoapySDR_free(bandwidth_ranges);
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("Invalid bandwidth: %lf [Hz]", params->bandwidth);
+        return NULL;
+    }
+    SoapySDR_free(bandwidth_ranges);
     if (SoapySDRDevice_setBandwidth(
-            receiver->device, SOAPY_SDR_RX, 0, bandwidth) != 0)
+            receiver->device, SOAPY_SDR_RX, 0, params->bandwidth) != 0)
     {
         spectrel_free_receiver(receiver);
         receiver = NULL;
@@ -110,7 +209,18 @@ spectrel_receiver spectrel_make_receiver(const char *driver,
         return NULL;
     }
 
-    if (SoapySDRDevice_setGain(receiver->device, SOAPY_SDR_RX, 0, gain) != 0)
+    // Set the gain.
+    SoapySDRRange gain_range =
+        SoapySDRDevice_getGainRange(receiver->device, SOAPY_SDR_RX, 0);
+    if (!is_value_in_range(params->gain, &gain_range))
+    {
+        spectrel_free_receiver(receiver);
+        receiver = NULL;
+        spectrel_print_error("Invalid gain: %lf [dB]", params->gain);
+        return NULL;
+    }
+    if (SoapySDRDevice_setGain(
+            receiver->device, SOAPY_SDR_RX, 0, params->gain) != 0)
     {
         spectrel_free_receiver(receiver);
         receiver = NULL;
@@ -131,6 +241,23 @@ spectrel_receiver spectrel_make_receiver(const char *driver,
     }
 
     return receiver;
+}
+
+int spectrel_get_parameters(spectrel_receiver receiver,
+                            spectrel_receiver_params_t *params)
+{
+    if (!params)
+    {
+        return SPECTREL_FAILURE;
+    }
+    params->frequency =
+        SoapySDRDevice_getFrequency(receiver->device, SOAPY_SDR_RX, 0);
+    params->sample_rate =
+        SoapySDRDevice_getSampleRate(receiver->device, SOAPY_SDR_RX, 0);
+    params->bandwidth =
+        SoapySDRDevice_getBandwidth(receiver->device, SOAPY_SDR_RX, 0);
+    params->gain = SoapySDRDevice_getGain(receiver->device, SOAPY_SDR_RX, 0);
+    return SPECTREL_SUCCESS;
 }
 
 int spectrel_activate_stream(spectrel_receiver receiver)
@@ -184,4 +311,14 @@ int spectrel_read_stream(spectrel_receiver receiver, spectrel_signal_t *buffer)
     }
 
     return SPECTREL_SUCCESS;
+}
+
+void spectrel_describe_receiver(spectrel_receiver receiver)
+{
+    spectrel_receiver_params_t params = {};
+    spectrel_get_parameters(receiver, &params);
+    printf("Frequency: %.4lf [Hz]\n", params.frequency);
+    printf("Sample rate: %.4lf [Hz]\n", params.sample_rate);
+    printf("Bandwidth: %.4lf [Hz]\n", params.bandwidth);
+    printf("Gain: %.4lf [dB]\n", params.gain);
 }


### PR DESCRIPTION
The program now checks the configurable receiver parameters (namely the frequency, bandwidth, sample rate and gain) against the device ranges provided by Soapy.